### PR TITLE
Implement initial code skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.25)
+project(BinaryBrain LANGUAGES CXX CUDA)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 17)
+
+add_subdirectory(include)
+add_subdirectory(src)
+add_subdirectory(cuda)
+add_subdirectory(python)
+add_subdirectory(tests)

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -1,0 +1,11 @@
+cuda_add_library(bb_cuda STATIC
+    forward_pass.cu
+    plasticity_kernels.cu
+    reward_kernels.cu
+    structural_kernels.cu
+)
+
+target_include_directories(bb_cuda PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/cuda/forward_pass.cu
+++ b/cuda/forward_pass.cu
@@ -1,0 +1,12 @@
+#include "xnor_popcount.cuh"
+#include "bb_core/neuron.hpp"
+#include "bb_core/synapse.hpp"
+
+__global__ void forward_kernel(bb::Neuron* neurons, const bb::SynapseBlock block) {
+    // stub kernel
+    unsigned idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < block.word_count) {
+        // example: toggle spike
+        neurons[idx].spike_mask_curr ^= 1ull;
+    }
+}

--- a/cuda/plasticity_kernels.cu
+++ b/cuda/plasticity_kernels.cu
@@ -1,0 +1,6 @@
+#include "bb_core/plasticity.hpp"
+
+using namespace bb;
+using namespace bb::kernels;
+
+// just expose the kernel defined in src/plasticity.cpp

--- a/cuda/reward_kernels.cu
+++ b/cuda/reward_kernels.cu
@@ -1,0 +1,1 @@
+// placeholder for reward computation kernels

--- a/cuda/structural_kernels.cu
+++ b/cuda/structural_kernels.cu
@@ -1,0 +1,3 @@
+#include "bb_core/structural_plasticity.hpp"
+
+// stub to compile; actual kernel is in src/structural_plasticity.cpp

--- a/cuda/xnor_popcount.cuh
+++ b/cuda/xnor_popcount.cuh
@@ -1,0 +1,18 @@
+#pragma once
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include "bb_types.hpp"
+
+namespace bb::cuda {
+    /** Warp-level XNOR + popcount on 64-bit lanes. */
+    __device__ inline int warp_xnor_popcount(weight_word_t a, weight_word_t b) {
+        return __popcll(~(a ^ b));
+    }
+
+#if __CUDA_ARCH__ >= 750
+    template <typename TileShape>
+    __device__ void mma_b1() {
+        // placeholder
+    }
+#endif
+} // namespace bb::cuda

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(bb_headers INTERFACE)
+target_include_directories(bb_headers INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/include/bb_config.hpp
+++ b/include/bb_config.hpp
@@ -1,0 +1,8 @@
+#pragma once
+namespace bb::cfg {
+    inline constexpr unsigned TILE_BITS   = 64;   // compile-time pack size
+    inline constexpr float    TICK_SEC    = 0.010f;
+    inline constexpr float    PRUNE_FREQ  = 1.0f;  // structural pass (s)
+    inline constexpr float    FLIP_PROB   = 0.01f; // base stochastic flip
+    // add more tunables here
+}

--- a/include/bb_core/actuator_pool.hpp
+++ b/include/bb_core/actuator_pool.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+
+namespace bb {
+class ActuatorPool {
+public:
+    explicit ActuatorPool(unsigned count) : actions_(count, 0) {}
+    uint8_t* data() { return actions_.data(); }
+    const uint8_t* data() const { return actions_.data(); }
+    unsigned size() const { return static_cast<unsigned>(actions_.size()); }
+
+private:
+    std::vector<uint8_t> actions_;
+};
+} // namespace bb

--- a/include/bb_core/network.hpp
+++ b/include/bb_core/network.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <vector>
+#include "neuron.hpp"
+#include "synapse.hpp"
+#include "reward_bus.hpp"
+#include "sensor_pool.hpp"
+#include "actuator_pool.hpp"
+
+namespace bb {
+class Network final {
+public:
+    explicit Network(unsigned num_neurons);
+
+    // Clock‐tick entry point (host)
+    void step(float dt_sec);
+
+    // Accessors
+    RewardBus&       reward();
+    const RewardBus& reward() const;
+
+private:
+    // === phases split out for clarity ===
+    void sense();                       // read SensorPool → neuron inputs
+    void compute_reward();              // populate RewardBus
+    void forward_pass_device();         // CUDA kernel launch
+    void apply_plasticity_device();     // plasticity kernels
+    void structural_pass_device();      // prune/grow kernels (≤1 Hz)
+
+    // --- state ---
+    std::vector<Neuron>         neurons_;
+    SynapseBlock                synapses_;
+    RewardBus                   reward_;
+    float                       structural_timer_{0.f};
+};
+} // namespace bb

--- a/include/bb_core/neuron.hpp
+++ b/include/bb_core/neuron.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "bb_types.hpp"
+
+namespace bb {
+struct Neuron final {
+    neuron_id_t id;
+    coord_t     x, y, z;   // immutable position
+    phase_t     phase;     // oscillator tag
+    uint8_t     target_rate; // homeostatic target (0-255)
+
+    // spike state buffers (double-buffered)
+    uint64_t    spike_mask_curr;
+    uint64_t    spike_mask_prev;
+
+    /** Compute intrinsic prediction and write to spike_mask_curr. */
+    __host__ __device__ void forward_intrinsic();
+};
+} // namespace bb

--- a/include/bb_core/plasticity.hpp
+++ b/include/bb_core/plasticity.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "bb_types.hpp"
+namespace bb::kernels {
+    /**
+     * CUDA kernel: apply three-factor bit-flip rule.
+     *  - Each thread owns one weight_word
+     *  - Uses RewardBus bits broadcast via CUDA constant memory.
+     */
+    __global__ void plasticity_step(const weight_word_t* pre_spike,
+                                    weight_word_t*       synapse_words,
+                                    unsigned             word_count,
+                                    uint8_t              flip_prob256);
+} // namespace bb::kernels

--- a/include/bb_core/reward_bus.hpp
+++ b/include/bb_core/reward_bus.hpp
@@ -1,0 +1,12 @@
+#pragma once
+namespace bb {
+struct RewardBus {
+    bool R_pos {false};   // pleasure
+    bool R_neg {false};   // pain / danger
+    bool S     {false};   // surprise / novelty
+    bool H     {true};    // homeostasis-ok
+
+    /** Update reward bits from sensor & prediction stats. */
+    void update(float prediction_err, bool danger_flag, float firing_rate_dev) noexcept;
+};
+} // namespace bb

--- a/include/bb_core/sensor_pool.hpp
+++ b/include/bb_core/sensor_pool.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+
+namespace bb {
+class SensorPool {
+public:
+    explicit SensorPool(unsigned count) : sensors_(count, 0) {}
+    uint8_t* data() { return sensors_.data(); }
+    const uint8_t* data() const { return sensors_.data(); }
+    unsigned size() const { return static_cast<unsigned>(sensors_.size()); }
+
+private:
+    std::vector<uint8_t> sensors_;
+};
+} // namespace bb

--- a/include/bb_core/structural_plasticity.hpp
+++ b/include/bb_core/structural_plasticity.hpp
@@ -1,0 +1,11 @@
+#include "bb_types.hpp"
+#pragma once
+namespace bb::kernels {
+    /**
+     * CUDA kernel: prune under-used synapses and allocate new ones where
+     * pre & S are frequent.
+     */
+    __global__ void structural_pass(weight_word_t* synapse_words,
+                                    uint32_t*      usage_counters,
+                                    float          prune_threshold);
+} // namespace bb::kernels

--- a/include/bb_core/synapse.hpp
+++ b/include/bb_core/synapse.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include "bb_types.hpp"
+
+namespace bb {
+struct SynapseBlock final {
+    weight_word_t* weights;  // device pointer (length = N_words)
+    unsigned       word_count;
+
+    /**
+     * Compute popcount(XNOR(a,b)) on packed 64-bit words.
+     * @param a Pointer to presynaptic packed activity.
+     * @param out_accum Int32 accumulator in shared memory.
+     */
+    __device__ void dot_xnor_popcount(const weight_word_t* a, int32_t* out_accum) const;
+};
+} // namespace bb

--- a/include/bb_types.hpp
+++ b/include/bb_types.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <cstdint>
+
+namespace bb {
+    using neuron_id_t   = uint32_t;    // supports up to 4 billion neurons
+    using coord_t       = uint16_t;    // fixed-point 16-bit coordinate per axis
+    using phase_t       = uint16_t;    // 8-bit freq | 8-bit phase
+    using weight_word_t = uint64_t;    // 64 binary synapses packed
+} // namespace bb

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,5 @@
+find_package(pybind11 REQUIRED)
+
+pybind11_add_module(_binarybrain bb_pybind.cpp)
+
+target_link_libraries(_binarybrain PRIVATE bb_core bb_cuda)

--- a/python/bb_pybind.cpp
+++ b/python/bb_pybind.cpp
@@ -1,0 +1,10 @@
+#include <pybind11/pybind11.h>
+#include "bb_core/network.hpp"
+
+PYBIND11_MODULE(_binarybrain, m) {
+    namespace py = pybind11;
+    py::class_<bb::Network>(m, "Network")
+        .def(py::init<unsigned>())
+        .def("step", &bb::Network::step)
+        .def_property_readonly("reward", &bb::Network::reward);
+}

--- a/python/brain.py
+++ b/python/brain.py
@@ -1,0 +1,13 @@
+import _binarybrain as _bb
+
+class Brain:
+    def __init__(self, n):
+        self._net = _bb.Network(n)
+
+    def tick(self, dt=0.010):
+        """Advance simulation by dt seconds."""
+        self._net.step(dt)
+
+    @property
+    def reward(self):
+        return self._net.reward

--- a/scripts/simulate.py
+++ b/scripts/simulate.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""CLI loop to run the brain on gym-like environments."""
+from python.brain import Brain
+
+def main():
+    brain = Brain(256)
+    for _ in range(10):
+        brain.tick()
+        print("Reward:", brain.reward)
+
+if __name__ == "__main__":
+    main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_library(bb_core STATIC
+    neuron.cpp
+    synapse.cpp
+    reward_bus.cpp
+    sensor_pool.cpp
+    actuator_pool.cpp
+    network.cpp
+    plasticity.cpp
+    structural_plasticity.cpp
+)
+
+target_include_directories(bb_core PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+add_dependencies(bb_core bb_headers)

--- a/src/actuator_pool.cpp
+++ b/src/actuator_pool.cpp
@@ -1,0 +1,3 @@
+#include "bb_core/actuator_pool.hpp"
+
+// no additional logic needed for stub

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -1,0 +1,27 @@
+#include "bb_core/network.hpp"
+#include "bb_config.hpp"
+
+using namespace bb;
+
+Network::Network(unsigned num_neurons) : neurons_(num_neurons) {}
+
+void Network::step(float dt_sec) {
+    sense();
+    compute_reward();
+    forward_pass_device();
+    apply_plasticity_device();
+    structural_timer_ += dt_sec;
+    if (structural_timer_ >= cfg::PRUNE_FREQ) {
+        structural_pass_device();
+        structural_timer_ = 0.f;
+    }
+}
+
+RewardBus& Network::reward() { return reward_; }
+const RewardBus& Network::reward() const { return reward_; }
+
+void Network::sense() { /* stub read sensors */ }
+void Network::compute_reward() { reward_.update(0.0f, false, 0.0f); }
+void Network::forward_pass_device() { /* launch CUDA kernels (stub) */ }
+void Network::apply_plasticity_device() { /* launch CUDA kernels (stub) */ }
+void Network::structural_pass_device() { /* launch CUDA kernels (stub) */ }

--- a/src/neuron.cpp
+++ b/src/neuron.cpp
@@ -1,0 +1,7 @@
+#include "bb_core/neuron.hpp"
+
+__host__ __device__ void bb::Neuron::forward_intrinsic() {
+    // simplistic oscillator toggle
+    spike_mask_prev = spike_mask_curr;
+    spike_mask_curr ^= 1ull;
+}

--- a/src/plasticity.cpp
+++ b/src/plasticity.cpp
@@ -1,0 +1,15 @@
+#include "bb_core/plasticity.hpp"
+
+__global__ void bb::kernels::plasticity_step(const weight_word_t* pre_spike,
+                                             weight_word_t*       synapse_words,
+                                             unsigned             word_count,
+                                             uint8_t              flip_prob256) {
+    unsigned idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= word_count) return;
+    weight_word_t w = synapse_words[idx];
+    weight_word_t p = pre_spike[idx];
+    if ((p ^ w) & 1ull && (flip_prob256 > 0)) {
+        w ^= 1ull;
+    }
+    synapse_words[idx] = w;
+}

--- a/src/reward_bus.cpp
+++ b/src/reward_bus.cpp
@@ -1,0 +1,8 @@
+#include "bb_core/reward_bus.hpp"
+
+void bb::RewardBus::update(float prediction_err, bool danger_flag, float firing_rate_dev) noexcept {
+    S = prediction_err > 0.5f;
+    R_neg = danger_flag;
+    H = firing_rate_dev < 0.1f;
+    R_pos = S && !R_neg && H;
+}

--- a/src/sensor_pool.cpp
+++ b/src/sensor_pool.cpp
@@ -1,0 +1,3 @@
+#include "bb_core/sensor_pool.hpp"
+
+// no additional logic needed for stub

--- a/src/structural_plasticity.cpp
+++ b/src/structural_plasticity.cpp
@@ -1,0 +1,10 @@
+#include "bb_core/structural_plasticity.hpp"
+
+__global__ void bb::kernels::structural_pass(weight_word_t* synapse_words,
+                                             uint32_t*      usage_counters,
+                                             float          prune_threshold) {
+    unsigned idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (usage_counters[idx] < prune_threshold) {
+        synapse_words[idx] = 0ull;
+    }
+}

--- a/src/synapse.cpp
+++ b/src/synapse.cpp
@@ -1,0 +1,10 @@
+#include "bb_core/synapse.hpp"
+#include <cuda_runtime.h>
+
+__device__ void bb::SynapseBlock::dot_xnor_popcount(const weight_word_t* a, int32_t* out_accum) const {
+    for (unsigned i = 0; i < word_count; ++i) {
+        weight_word_t x = a[i] ^ weights[i]; // XOR
+        int pc = __popcll(~x); // XNOR then popcount
+        atomicAdd(out_accum, pc);
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+enable_testing()
+find_package(GTest REQUIRED)
+
+add_executable(tests
+    test_forward.cpp
+    test_plasticity.cpp
+    test_reward.cpp
+    test_structural.cpp
+)
+
+target_link_libraries(tests PRIVATE GTest::gtest_main bb_core)
+add_test(NAME all_tests COMMAND tests)

--- a/tests/test_forward.cpp
+++ b/tests/test_forward.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+#include "bb_core/network.hpp"
+
+TEST(Forward, XnorPopcountDot) {
+    bb::Network net(1024);
+    net.step(0.010f);
+    ASSERT_TRUE(true); // TODO: add proper assertions
+}

--- a/tests/test_plasticity.cpp
+++ b/tests/test_plasticity.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+#include "bb_core/plasticity.hpp"
+
+TEST(Plasticity, KernelStub) {
+    ASSERT_TRUE(true); // placeholder
+}

--- a/tests/test_reward.cpp
+++ b/tests/test_reward.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+#include "bb_core/reward_bus.hpp"
+
+TEST(Reward, Update) {
+    bb::RewardBus bus;
+    bus.update(1.0f, false, 0.0f);
+    ASSERT_TRUE(bus.S);
+}

--- a/tests/test_structural.cpp
+++ b/tests/test_structural.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+#include "bb_core/structural_plasticity.hpp"
+
+TEST(Structural, KernelStub) {
+    ASSERT_TRUE(true); // placeholder
+}


### PR DESCRIPTION
## Summary
- add CMake skeleton with subdirectories
- stub out headers and implementations for neural network core
- provide CUDA kernel placeholders and pybind11 bindings
- sketch Python helper and utility scripts
- include unit test stubs

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6851870916a883339ebf6163773ed3f0